### PR TITLE
Removes has_many Association From User Decorator

### DIFF
--- a/app/models/spree/user_decorator.rb
+++ b/app/models/spree/user_decorator.rb
@@ -1,7 +1,4 @@
 Spree.user_class.class_eval do
-
-  has_many :user_authentications, :dependent => :destroy
-
   def past_bill_addresses
     past_addresses :bill_address
   end
@@ -27,6 +24,4 @@ private
   def past_orders_with_most_recent_first(address_type)
     completed_orders.includes(address_type => [:state, :country])
   end
-
 end
-


### PR DESCRIPTION
The `UserAuthentication` model is provided by the `spree_social` extension, which makes the gem a surprise dependency for Sprangular. Moreover, spree_social itself [decorates the User class](https://github.com/radar/spree_social/blob/master/app/models/spree/user_decorator.rb#L2) with this association, so defining it here is superfluous.

(I also cleaned up some whitespace. :smile: )