### PR TITLE
Fixes Template Overriding when Digesting Assets

### DIFF
--- a/app/helpers/sprangular/application_helper.rb
+++ b/app/helpers/sprangular/application_helper.rb
@@ -54,7 +54,7 @@ module Sprangular
       end
 
       Dir["app/assets/templates/#{dir}/**"].inject(files) do |hash, path|
-        asset_path = asset_path(path.gsub("/app/assets/templates/", ""))
+        asset_path = asset_path(path.gsub("app/assets/templates/", ""))
         asset_path = asset_path.gsub(/^\/app\/assets\/templates/, '/assets').gsub(/.slim$/, '')
 
         hash[asset_path] = Tilt.new(path).render.html_safe


### PR DESCRIPTION
Paths being returned by `Dir["app/assets/templates/#{dir}/**"]` don't contain leading slashes. This happens not to matter, as long as the host app hasn't enabled asset digests. If the host app _has_, though, template overrides stop working, because the host app's template key doesn't match the Sprangular engine's, and the former doesn't overwrite the latter in the hash.

Fixes #64.