### PR TITLE
Enable Helper Methods in Cached Templates

### DIFF
--- a/app/helpers/sprangular/application_helper.rb
+++ b/app/helpers/sprangular/application_helper.rb
@@ -54,10 +54,13 @@ module Sprangular
       end
 
       Dir["app/assets/templates/#{dir}/**"].inject(files) do |hash, path|
-        asset_path = asset_path(path.gsub("app/assets/templates/", ""))
-        asset_path = asset_path.gsub(/^\/app\/assets\/templates/, '/assets').gsub(/.slim$/, '')
+        sprockets_path = path.gsub("app/assets/templates/", "")
+        
+        asset_path = asset_path(sprockets_path).
+          gsub(/^\/app\/assets\/templates/, '/assets').
+          gsub(/.slim$/, '')
 
-        hash[asset_path] = Tilt.new(path).render.html_safe
+        hash[asset_path] = Rails.application.assets.find_asset(sprockets_path).body
         hash
       end
     end


### PR DESCRIPTION
A raw Tilt instance doesn't have a view context to make Rails helper calls against, whereas Sprockets instances do. I'm not sure this is the cleanest way to use Sprockets to render these cached templates, but this _does_ work.